### PR TITLE
Fixes to Common Voice example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.wav
 .tox
 __pycache__
+
+#
+.DS_Store
+.idea/*

--- a/examples/common-voice/config.xvector-NB.yaml
+++ b/examples/common-voice/config.xvector-NB.yaml
@@ -34,7 +34,7 @@ features:
     frame_step_ms: 10
     fft_length: 1024
   melspectrogram:
-    num_mel_bins: 64
+    num_mel_bins: 40
     fmin: 20
     fmax: 7000
   window_normalization:
@@ -45,11 +45,11 @@ features:
 embeddings:
   extractors:
     # This is the experiment we performed using config.yaml
-    - experiment_name: commonvoice-lang4
+    - experiment_name: common-voice-4
       model:
         key: xvector
       cache_directory: ./lidbox-cache
-      input_shape: [198, 64]
+      input_shape: [198, 40]
       output_shape: [4]
       best_checkpoint:
         monitor: val_loss
@@ -61,7 +61,7 @@ embeddings:
 # See lidbox.embeddings.sklearn_utils
 sklearn_experiment:
   cache_directory: ./lidbox-cache
-  name: commonvoice-lang4-embeddings
+  name: common-voice-4-embeddings
   model:
     key: naive_bayes
   data:

--- a/examples/common-voice/config.xvector-NB.yaml
+++ b/examples/common-voice/config.xvector-NB.yaml
@@ -1,5 +1,5 @@
 datasets:
-  - key: common-voice
+  - key: common-voice-4
     labels:
       - br
       - et

--- a/examples/common-voice/scripts/prepare.bash
+++ b/examples/common-voice/scripts/prepare.bash
@@ -23,6 +23,7 @@ datasets=(
 downloads_dir=./downloads
 # Where to unpack all tars and convert mp3s to wavs
 output_dir=./data
+cv_artifact=cv-corpus-5-2020-06-22
 # Ignore files shorter than 1 second
 min_file_dur_sec=1
 # Resample all wav-files to this rate before writing
@@ -63,8 +64,9 @@ set -e
 for language in ${datasets[*]}; do
 	tarfile=$downloads_dir/${language}.tar.gz
 	echo "unpacking '$tarfile'"
-	mkdir --parents --verbose $output_dir/$language
+	mkdir -pv $output_dir/$language
 	tar zxf $tarfile -C $output_dir/$language
+	mv $output_dir/$language/$cv_artifact/$language/* $output_dir/$language
 	metadata_tsv=$output_dir/$language/validated.tsv
 	mp3_name_list=$(cut -f2 $metadata_tsv | tail -n +2 | shuf)
 	if [ -z "$mp3_name_list" ]; then
@@ -76,10 +78,10 @@ for language in ${datasets[*]}; do
 	total_sec=0
 	total_files=0
 	wavs_dir=$output_dir/$language/16k_wavs
-	mkdir --verbose $wavs_dir
+	mkdir -pv $wavs_dir
 	echo "converting $num_validated mp3 files to wav files into directory '$wavs_dir'"
 	for mp3_name in $mp3_name_list; do
-		uttid=$(basename --suffix .mp3 $mp3_name)
+		uttid=$(basename -s .mp3 $mp3_name)
 		mp3_path=$output_dir/$language/clips/$mp3_name
 		if [ ! -f $mp3_path ]; then
 			echo "skipping non-existing mp3 file '$mp3_path'"


### PR DESCRIPTION
This makes the following fixes and closes #3 
* `examples/common-voice/scripts/prepare.bash`
	- moved unzipped files to correct location to mirror structure changes in Common Voice downloads
	- fixed incorrect options with `mkdir` and `basename` commands
* `examples/common-voice/config.xvector-NB.yaml`
	- matched the experiment name, input_shape and num_mel_bins for both config files
* `.gitignore`
	- ignored osx and ide artifacts